### PR TITLE
Refactor styles for easier theming

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -359,18 +359,18 @@ useHead({
 }
 
 ::-webkit-scrollbar-thumb {
-  background: theme('colors.editor.hover');
+  background: var(--scrollbar-thumb);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #3a3f52;
+  background: var(--scrollbar-thumb-hover);
 }
 
 /* Custom CodeMirror theme for Linear-style markdown highlighting */
 .cm-editor {
   background-color: theme('colors.editor.bg') !important;
-  color: #b4bcd0 !important;
+  color: var(--color-text-primary) !important;
   border: none !important;
 }
 
@@ -408,19 +408,19 @@ useHead({
 }
 
 .cm-header.cm-header-1 {
-  color: #ffffff !important;
+  color: var(--cm-heading-1) !important;
   font-size: 1.875rem !important;
   font-weight: 700 !important;
 }
 
 .cm-header.cm-header-2 {
-  color: #e6edf3 !important;
+  color: var(--cm-heading-2) !important;
   font-size: 1.5rem !important;
   font-weight: 600 !important;
 }
 
 .cm-header.cm-header-3 {
-  color: #d2d9e0 !important;
+  color: var(--cm-heading-3) !important;
   font-size: 1.25rem !important;
   font-weight: 600 !important;
 }
@@ -428,67 +428,67 @@ useHead({
 .cm-header.cm-header-4,
 .cm-header.cm-header-5,
 .cm-header.cm-header-6 {
-  color: #c9d1d9 !important;
+  color: var(--cm-heading-other) !important;
   font-weight: 600 !important;
 }
 
 /* Markdown tokens */
 .cm-strong {
-  color: #ffffff !important;
+  color: var(--cm-strong) !important;
   font-weight: 600 !important;
 }
 
 .cm-emphasis {
-  color: #e6edf3 !important;
+  color: var(--cm-emphasis) !important;
   font-style: italic !important;
 }
 
 .cm-strikethrough {
-  color: #8b949e !important;
+  color: var(--cm-strikethrough) !important;
   text-decoration: line-through !important;
 }
 
 .cm-code {
   background: rgba(110, 118, 129, 0.15) !important;
-  color: #ff7b72 !important;
+  color: var(--cm-code) !important;
   padding: 0.125rem 0.25rem !important;
   border-radius: 0.25rem !important;
 }
 
 .cm-link {
-  color: #58a6ff !important;
+  color: var(--cm-link) !important;
   text-decoration: none !important;
 }
 
 .cm-url {
-  color: #58a6ff !important;
+  color: var(--cm-link) !important;
 }
 
 .cm-quote {
-  color: #8b949e !important;
+  color: var(--cm-quote) !important;
   font-style: italic !important;
 }
 
 .cm-list {
-  color: #58a6ff !important;
+  color: var(--cm-link) !important;
 }
 
 .cm-hr {
-  color: #30363d !important;
+  color: var(--cm-hr) !important;
 }
 
 /* Code blocks */
 .cm-meta {
-  color: #8b949e !important;
+  color: var(--cm-meta) !important;
 }
 
 /* Active line highlighting */
 .cm-activeLine {
-  background-color: rgba(110, 118, 129, 0.05) !important;
+  background-color: var(--cm-active-line-bg) !important;
 }
 
 .cm-activeLineGutter {
-  background-color: rgba(110, 118, 129, 0.05) !important;
+  background-color: var(--cm-active-line-bg) !important;
 }
 
 /* Line numbers if enabled */

--- a/components/MyCodeMirror.vue
+++ b/components/MyCodeMirror.vue
@@ -52,50 +52,50 @@ const emit = defineEmits<{
   (event: 'update', viewUpdate: ViewUpdate): void
 }>()
 
-// Clean monochromatic theme using hardcoded CSS colors
+// Clean monochromatic theme using CSS variables for easy customization
 const customHighlightStyle = HighlightStyle.define([
-  // Headers - Pure white for maximum contrast and prominence
-  { tag: tags.heading1, color: "#ffffff", fontWeight: "bold", fontSize: "1.2em" },
-  { tag: tags.heading2, color: "#ffffff", fontWeight: "bold", fontSize: "1.1em" },
-  { tag: tags.heading3, color: "#ffffff", fontWeight: "bold" },
-  { tag: tags.heading4, color: "#ffffff", fontWeight: "bold" },
-  { tag: tags.heading5, color: "#ffffff", fontWeight: "bold" },
-  { tag: tags.heading6, color: "#ffffff", fontWeight: "bold" },
+  // Headers
+  { tag: tags.heading1, color: 'var(--cm-heading-1)', fontWeight: 'bold', fontSize: '1.2em' },
+  { tag: tags.heading2, color: 'var(--cm-heading-2)', fontWeight: 'bold', fontSize: '1.1em' },
+  { tag: tags.heading3, color: 'var(--cm-heading-3)', fontWeight: 'bold' },
+  { tag: tags.heading4, color: 'var(--cm-heading-other)', fontWeight: 'bold' },
+  { tag: tags.heading5, color: 'var(--cm-heading-other)', fontWeight: 'bold' },
+  { tag: tags.heading6, color: 'var(--cm-heading-other)', fontWeight: 'bold' },
   
-  // Main text - Light gray for comfortable reading
-  { tag: tags.content, color: "#d1d5db" },
+  // Main text
+  { tag: tags.content, color: 'var(--color-text-primary)' },
   
-  // Code elements - Different shades of gray for hierarchy
-  { tag: tags.keyword, color: "#f3f4f6", fontWeight: "bold" },
-  { tag: tags.string, color: "#e5e7eb" },
-  { tag: tags.comment, color: "#9ca3af", fontStyle: "italic" },
-  { tag: tags.variableName, color: "#d1d5db" },
-  { tag: tags.function(tags.variableName), color: "#f9fafb" },
+  // Code elements
+  { tag: tags.keyword, color: 'var(--cm-code)', fontWeight: 'bold' },
+  { tag: tags.string, color: 'var(--cm-code)' },
+  { tag: tags.comment, color: 'var(--cm-strikethrough)', fontStyle: 'italic' },
+  { tag: tags.variableName, color: 'var(--color-text-primary)' },
+  { tag: tags.function(tags.variableName), color: 'var(--color-text-primary)' },
   
   // Numbers and constants
-  { tag: tags.number, color: "#e5e7eb" },
-  { tag: tags.bool, color: "#f3f4f6" },
-  { tag: tags.null, color: "#f3f4f6" },
+  { tag: tags.number, color: 'var(--cm-code)' },
+  { tag: tags.bool, color: 'var(--cm-code)' },
+  { tag: tags.null, color: 'var(--cm-code)' },
   
   // Punctuation and operators
-  { tag: tags.operator, color: "#d1d5db" },
-  { tag: tags.punctuation, color: "#d1d5db" },
-  { tag: tags.bracket, color: "#f3f4f6" },
+  { tag: tags.operator, color: 'var(--color-text-primary)' },
+  { tag: tags.punctuation, color: 'var(--color-text-primary)' },
+  { tag: tags.bracket, color: 'var(--color-text-primary)' },
   
   // Special markdown elements
-  { tag: tags.link, color: "#ffffff", textDecoration: "underline" },
-  { tag: tags.emphasis, color: "#d1d5db", fontStyle: "italic" },
-  { tag: tags.strong, color: "#ffffff", fontWeight: "bold" },
-  { tag: tags.strikethrough, color: "#9ca3af", textDecoration: "line-through" },
+  { tag: tags.link, color: 'var(--cm-link)', textDecoration: 'underline' },
+  { tag: tags.emphasis, color: 'var(--cm-emphasis)', fontStyle: 'italic' },
+  { tag: tags.strong, color: 'var(--cm-strong)', fontWeight: 'bold' },
+  { tag: tags.strikethrough, color: 'var(--cm-strikethrough)', textDecoration: 'line-through' },
   
   // Markdown specific elements
-  { tag: tags.quote, color: "#9ca3af", fontStyle: "italic" },
-  { tag: tags.list, color: "#e5e7eb" },
-  { tag: tags.monospace, color: "#f3f4f6", backgroundColor: "#374151", padding: "2px 4px", borderRadius: "3px" },
+  { tag: tags.quote, color: 'var(--cm-quote)', fontStyle: 'italic' },
+  { tag: tags.list, color: 'var(--cm-link)' },
+  { tag: tags.monospace, color: 'var(--cm-code)', backgroundColor: 'var(--cm-monospace-bg)', padding: '2px 4px', borderRadius: '3px' },
   
   // Vim keys and commands - pure white for prominence
-  { tag: tags.labelName, color: "#ffffff" },
-  { tag: tags.special(tags.string), color: "#ffffff" }
+  { tag: tags.labelName, color: 'var(--cm-strong)' },
+  { tag: tags.special(tags.string), color: 'var(--cm-strong)' }
 ])
 
 const { lineNumberCompartment, getLineNumberExtension, handleLineNumberUpdate } = useLineNumbers()

--- a/components/ShortcutsModal.vue
+++ b/components/ShortcutsModal.vue
@@ -138,11 +138,11 @@ onKeyUp('Escape', () => {
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: #4b5563;
+  background: var(--shortcuts-scrollbar-thumb);
   border-radius: 3px;
 }
 
 .overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: #6b7280;
+  background: var(--shortcuts-scrollbar-thumb-hover);
 }
 </style> 

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -47,6 +47,39 @@ export default defineConfig({
           :root {
             --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'avenir next', avenir, 'segoe ui', 'helvetica neue', helvetica, Ubuntu, roboto, noto, arial, sans-serif;
             --font-mono: 'SF Mono', Monaco, Inconsolata, 'Roboto Mono', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace;
+            /* Theme colors */
+            --color-editor-bg: ${theme.colors.editor.bg};
+            --color-editor-border: ${theme.colors.editor.border};
+            --color-editor-divider: ${theme.colors.editor.divider};
+            --color-editor-hover: ${theme.colors.editor.hover};
+            --color-editor-active: ${theme.colors.editor.active};
+            --color-text-primary: ${theme.colors.text.primary};
+            --color-text-secondary: ${theme.colors.text.secondary};
+            --color-window-close: ${theme.colors.window.close};
+            --color-window-minimize: ${theme.colors.window.minimize};
+            --color-window-maximize: ${theme.colors.window.maximize};
+            --color-surface-primary: ${theme.colors.surface.primary};
+            --color-surface-secondary: ${theme.colors.surface.secondary};
+            /* Scrollbar colors */
+            --scrollbar-thumb: #3a3f52;
+            --scrollbar-thumb-hover: #4a5068;
+            --shortcuts-scrollbar-thumb: #4b5563;
+            --shortcuts-scrollbar-thumb-hover: #6b7280;
+            /* CodeMirror highlight colors */
+            --cm-heading-1: #ffffff;
+            --cm-heading-2: #e6edf3;
+            --cm-heading-3: #d2d9e0;
+            --cm-heading-other: #c9d1d9;
+            --cm-strong: #ffffff;
+            --cm-emphasis: #e6edf3;
+            --cm-strikethrough: #8b949e;
+            --cm-code: #ff7b72;
+            --cm-link: #58a6ff;
+            --cm-quote: #8b949e;
+            --cm-hr: #30363d;
+            --cm-meta: #8b949e;
+            --cm-active-line-bg: rgba(110, 118, 129, 0.05);
+            --cm-monospace-bg: #374151;
           }
           
           * {
@@ -117,12 +150,12 @@ export default defineConfig({
           }
 
           .prose pre::-webkit-scrollbar-thumb {
-            background: #3a3f52;
+            background: var(--scrollbar-thumb);
             border-radius: 3px;
           }
 
           .prose pre::-webkit-scrollbar-thumb:hover {
-            background: #4a5068;
+            background: var(--scrollbar-thumb-hover);
           }
         `
       }


### PR DESCRIPTION
## Summary
- expose CSS variables for theme colors in Uno config
- use new variables in scrollbars and CodeMirror styles
- switch custom highlight rules to rely on CSS variables

## Testing
- `pnpm install` *(fails: Request was cancelled)*
- `pnpm build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68446ca3b914832499b60999bb88b1b7