### PR TITLE
Add settings shortcut test

### DIFF
--- a/tests/features/keyboard-shortcuts.feature
+++ b/tests/features/keyboard-shortcuts.feature
@@ -85,4 +85,9 @@ Feature: Keyboard Shortcuts Modal
     When I click the keyboard shortcuts button
     Then all shortcuts should have visible key combinations
     And no shortcuts should be missing key bindings
-    And settings shortcuts should have proper key combinations 
+    And settings shortcuts should have proper key combinations
+
+  Scenario: Open settings modal via keyboard shortcut
+    Given I am on the MarkVim homepage
+    When I open the settings modal with keyboard shortcut
+    Then the settings modal should be visible

--- a/tests/page-objects/markvim-page.ts
+++ b/tests/page-objects/markvim-page.ts
@@ -22,6 +22,8 @@ export class MarkVimPage {
   readonly keyboardShortcutsButton: Locator
   readonly keyboardShortcutsModal: Locator
   readonly keyboardShortcutsModalTitle: Locator
+  readonly settingsButton: Locator
+  readonly settingsModal: Locator
 
   constructor(page: Page) {
     this.page = page
@@ -44,6 +46,8 @@ export class MarkVimPage {
     this.keyboardShortcutsButton = page.locator('[data-testid="keyboard-shortcuts-button"]')
     this.keyboardShortcutsModal = page.locator('[data-testid="keyboard-shortcuts-modal"]')
     this.keyboardShortcutsModalTitle = page.locator('[data-testid="keyboard-shortcuts-modal"] h2')
+    this.settingsButton = page.locator('[data-testid="settings-button"]')
+    this.settingsModal = page.locator('[data-testid="settings-modal"]')
   }
 
   async navigate(): Promise<void> {
@@ -150,6 +154,19 @@ export class MarkVimPage {
   async verifyMarkdownRendering(): Promise<void> {
     await expect(this.previewContent.locator('h1')).toBeVisible()
     await expect(this.previewContent.locator('strong')).toBeVisible()
+  }
+
+  async openSettingsWithKeyboard(): Promise<void> {
+    await this.page.keyboard.press('KeyG')
+    await this.page.keyboard.press('KeyS')
+  }
+
+  async verifySettingsModalVisible(): Promise<void> {
+    await expect(this.settingsModal).toBeVisible()
+  }
+
+  async verifySettingsModalHidden(): Promise<void> {
+    await expect(this.settingsModal).not.toBeVisible()
   }
 
   async toggleSidebarWithKeyboard(): Promise<void> {

--- a/tests/steps/keyboard-shortcuts.steps.ts
+++ b/tests/steps/keyboard-shortcuts.steps.ts
@@ -13,6 +13,11 @@ When('I open the keyboard shortcuts modal', async function (this: MarkVimWorld) 
   await markVimPage.openKeyboardShortcutsModal()
 })
 
+When('I open the settings modal with keyboard shortcut', async function (this: MarkVimWorld) {
+  const markVimPage = await getMarkVimPage(this)
+  await markVimPage.openSettingsWithKeyboard()
+})
+
 Given('the keyboard shortcuts modal is open', async function (this: MarkVimWorld) {
   const markVimPage = await getMarkVimPage(this)
   await markVimPage.clickKeyboardShortcutsButton()


### PR DESCRIPTION
## Summary
- extend MarkVimPage with settings locators and helpers
- add step to open settings modal via keyboard
- test opening settings using `g` then `s`

## Testing
- `pnpm test:e2e` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6846c5d9ad408324b5c12cba4d2855e3