### PR TITLE
Add theme toggle e2e tests

### DIFF
--- a/tests/features/settings-theme.feature
+++ b/tests/features/settings-theme.feature
@@ -1,0 +1,16 @@
+Feature: Settings Theme Selection
+
+  Background:
+    Given I am on the MarkVim homepage
+    And I open the settings modal
+
+  Scenario: Change theme to light
+    When I change the theme to "light"
+    Then the theme should be stored in localStorage as "light"
+
+  Scenario: Theme preference persists across reloads
+    When I change the theme to "light"
+    And I press the key "Escape"
+    And I reload the page
+    When I open the settings modal
+    Then the theme should be stored in localStorage as "light"

--- a/tests/page-objects/markvim-page.ts
+++ b/tests/page-objects/markvim-page.ts
@@ -305,6 +305,29 @@ export class MarkVimPage {
       expect(statusText).not.toMatch(/\b(NORMAL|INSERT|VISUAL|REPLACE)\b/)
     }
   }
+
+  async changeTheme(theme: string): Promise<void> {
+    await this.page.getByText(theme).click()
+  }
+
+  async getStoredTheme(): Promise<string | null> {
+    return await this.page.evaluate(() => {
+      const stored = localStorage.getItem('markvim-settings')
+      if (!stored)
+        return null
+      try {
+        return JSON.parse(stored).theme as string
+      }
+      catch {
+        return null
+      }
+    })
+  }
+
+  async verifyThemeInLocalStorage(expected: string): Promise<void> {
+    const storedTheme = await this.getStoredTheme()
+    expect(storedTheme).toBe(expected)
+  }
 }
 
 // Helper function to get MarkVimPage instance

--- a/tests/steps/settings-theme.steps.ts
+++ b/tests/steps/settings-theme.steps.ts
@@ -1,0 +1,15 @@
+import type { MarkVimWorld } from '../support/world.js'
+import { Then, When } from '@cucumber/cucumber'
+import { expect } from '@playwright/test'
+import { getMarkVimPage } from '../page-objects/markvim-page.js'
+
+When('I change the theme to {string}', async function (this: MarkVimWorld, theme: string) {
+  const markVimPage = await getMarkVimPage(this)
+  await markVimPage.changeTheme(theme)
+})
+
+Then('the theme should be stored in localStorage as {string}', async function (this: MarkVimWorld, theme: string) {
+  const markVimPage = await getMarkVimPage(this)
+  const storedTheme = await markVimPage.getStoredTheme()
+  expect(storedTheme).toBe(theme)
+})


### PR DESCRIPTION
## Summary
- add tests for switching the editor theme
- update page object with helpers for theme actions

## Testing
- `eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6846ccead3b88324a37ff2dd25e8840b