### PR TITLE
Fix command line icon for new document

### DIFF
--- a/src/modules/documents/components/DocumentList.vue
+++ b/src/modules/documents/components/DocumentList.vue
@@ -83,7 +83,7 @@ function formatDate(timestamp: number): string {
         @click="handleCreateDocument"
       >
         <Icon
-          name="lucide:plus"
+          name="i-lucide-plus"
           class="h-4 w-4 transition-transform duration-200 group-hover:scale-110"
         />
       </button>


### PR DESCRIPTION
The icon name `lucide:plus` in `src/modules/documents/components/DocumentList.vue` was updated to `i-lucide-plus`.

*   This change corrects the icon format to align with Nuxt Icon's expected convention for Lucide icons.
*   The update resolves a display bug where the "create new document" icon was not rendered.